### PR TITLE
add validation before running, and inform users that it's started

### DIFF
--- a/bin/xclisten
+++ b/bin/xclisten
@@ -29,8 +29,9 @@ OptionParser.new do |opts|
   opts.parse!
 end
 
-pid = fork     { XCListen.new(@options).listen }
-trap("SIGINT") { Process.kill(9, pid) }
+if XCListen.can_run?
+  pid = fork     { XCListen.new(@options).listen }
+  trap("SIGINT") { Process.kill(9, pid) }
 
-Process.wait(pid)
-
+  Process.wait(pid)
+end

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -4,9 +4,7 @@ require 'listen'
 
 class XCListen
 
-  attr_reader :device
-  attr_reader :scheme
-  attr_reader :sdk
+  attr_reader :device, :scheme, :sdk
 
   def initialize(opts = {})
     @device = IOS_DEVICES[opts[:device]] || IOS_DEVICES['iphone5s']
@@ -19,6 +17,19 @@ class XCListen
     'iphone5' => 'iPhone Retina (4-inch)',
     'iphone4' => 'iPhone Retina (3.5-inch)'
   }
+
+  def self.can_run?
+    if Dir.entries(Dir.pwd).detect { |f| f =~ /.xcworkspace/ }.nil?
+      puts "Please run xclisten from a directory with an xcworkspace."
+      return false;
+    end
+    
+    true
+  end
+
+  def has_workspaces?
+    workspace_name.nil?
+  end
 
   #TODO: make this recursive
   def workspace_name
@@ -44,7 +55,8 @@ class XCListen
     ShellTask.run("#{xcodebuild} test 2> xcodebuild_error.log | xcpretty -tc")
   end
 
-  def listen
+  def listen    
+    puts "Started xclistening to #{workspace_name}"
     ignored = [/.git/, /.xc(odeproj|workspace|userdata|scheme|config)/, /.lock$/, /\.txt$/, /\.log$/]
 
     listener = Listen.to(Dir.pwd, :ignore => ignored) do |modified, added, removed|

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -27,10 +27,6 @@ class XCListen
     true
   end
 
-  def has_workspaces?
-    workspace_name.nil?
-  end
-
   #TODO: make this recursive
   def workspace_name
     Dir.entries(Dir.pwd).detect { |f| f =~ /.xcworkspace/ }


### PR DESCRIPTION
before

```
main
~ xclisten
/Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/lib/xclisten.rb:30:in `project_name': undefined method `split' for nil:NilClass (NoMethodError)
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/lib/xclisten.rb:13:in `initialize'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/bin/xclisten:32:in `new'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/bin/xclisten:32:in `block in <top (required)>'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/bin/xclisten:32:in `fork'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/xclisten-0.0.3/bin/xclisten:32:in `<top (required)>'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/xclisten:23:in `load'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/xclisten:23:in `<main>'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `<main>'
```

after 

```
~/s/r/xclisten (master ⚡=) xclisten
Please run xclisten from a directory with an xcworkspace.
```

and 

```
~/s/i/energy (toolbar_polish ↩) xclisten
Started xclistening to Artsy Folio.xcworkspace
```
