### PR TITLE
Make xcworkspace search work recursively

### DIFF
--- a/bin/xclisten
+++ b/bin/xclisten
@@ -29,8 +29,13 @@ OptionParser.new do |opts|
   opts.parse!
 end
 
-pid = fork     { XCListen.new(@options).listen }
-trap("SIGINT") { Process.kill(9, pid) }
+if XCListen.can_run?
+  pid = fork     { XCListen.new(@options).listen }
+  trap("SIGINT") { Process.kill(9, pid) }
+else
+  puts "[!] No xcworkspace found in this directory (or any child directories)"
+  exit 1
+end
 
 Process.wait(pid)
 

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -47,6 +47,7 @@ class XCListen
   end
 
   def listen
+    puts "Started xclistening to #{workspace_path}"
     ignored = [/.git/, /.xc(odeproj|workspace|userdata|scheme|config)/, /.lock$/, /\.txt$/, /\.log$/]
 
     listener = Listen.to(Dir.pwd, :ignore => ignored) do |modified, added, removed|

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -20,12 +20,16 @@ class XCListen
     'iphone4' => 'iPhone Retina (3.5-inch)'
   }
 
+  def self.can_run?
+    self.new.project_name != nil
+  end
+
   def workspace_path
-    @@workspace_path ||= Dir.glob("**/*.xcworkspace").select {|p| !p.include? "xcodeproj"}.first
+    @workspace_path ||= Dir.glob("**/*.xcworkspace").select {|p| !p.include? "xcodeproj"}.first
   end
 
   def project_name
-    File.basename(workspace_path, ".*")
+    File.basename(workspace_path, ".*") if workspace_path
   end
 
   def xcodebuild

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -37,9 +37,11 @@ class XCListen
   end
 
   def install_pods
-    system 'pod install'
-    puts 'Giving Xcode some time to index...'
-    sleep 10
+    Dir.chdir(File.dirname(workspace_path)) do
+      system 'pod install'
+      puts 'Giving Xcode some time to index...'
+      sleep 10
+    end
   end
 
   def run_tests

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -20,18 +20,16 @@ class XCListen
     'iphone4' => 'iPhone Retina (3.5-inch)'
   }
 
-  #TODO: make this recursive
-  def workspace_name
-    Dir.entries(Dir.pwd).detect { |f| f =~ /.xcworkspace/ }
+  def workspace_path
+    @@workspace_path ||= Dir.glob("**/*.xcworkspace").select {|p| !p.include? "xcodeproj"}.first
   end
 
-  #TODO: when workspace_name gets recursive, use `basename`
   def project_name
-    workspace_name.split('.').first
+    File.basename(workspace_path, ".*")
   end
 
   def xcodebuild
-    "xcodebuild -workspace #{workspace_name} -scheme #{@scheme} -sdk #{@sdk} -destination 'name=#{@device}'"
+    "xcodebuild -workspace #{workspace_path} -scheme #{@scheme} -sdk #{@sdk} -destination 'name=#{@device}'"
   end
 
   def install_pods

--- a/spec/lib/xclisten_spec.rb
+++ b/spec/lib/xclisten_spec.rb
@@ -11,7 +11,7 @@ class XCListen
     end
 
     before(:each) do
-      Dir.stub(:entries).and_return(['SampleProject.xcworkspace'])
+      Dir.stub(:glob).and_return(['SampleProject.xcworkspace'])
     end
 
     context "Defaults" do


### PR DESCRIPTION
## Changes
- checks subdirectories for xcworkspaces
- notifies user which workspace is being monitored like: `Started xclistening to Alcatraz/Alcatraz.xcworkspace`
- notifies user when no workspaces are found like: `[!] No xcworkspace found in this directory (or any child directories)`
