### PR TITLE
Update names of iPad devices...

### DIFF
--- a/bin/xclisten
+++ b/bin/xclisten
@@ -19,7 +19,7 @@ OptionParser.new do |opts|
   opts.on('--ios', '[DEFAULT] Run with iOS sdk') do
     @options[:sdk] = 'iphonesimulator'
   end
-  opts.on('-d', '--device DEVICE', 'Simulated device [iphone5s, iphone5, iphone4, ipad2, ipad4, ipad_air]. Default is iphone5s') do |device|
+  opts.on('-d', '--device DEVICE', "Simulated device [#{IOS_DEVICES.keys * ','}]. Default is iphone5s") do |device|
     @options[:device] = device
   end
   opts.on('-s', '--scheme SCHEME', 'BYOS (Bring your own scheme)') do |scheme|

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -50,7 +50,7 @@ class XCListen
   end
 
   def run_tests
-    ShellTask.run("#{xcodebuild} test 2> xcodebuild_error.log | xcpretty -tc")
+    ShellTask.run("#{xcodebuild} test 2>| xcodebuild_error.log | xcpretty -tc")
   end
 
   #TODO TEST THIS SPIKE

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -2,6 +2,17 @@ require 'xclisten/version'
 require 'xclisten/shell_task'
 require 'listen'
 
+IOS_DEVICES = {
+  # TODO Update iPhone names.
+  'iphone5s' => 'iPhone Retina (4-inch 64-bit)',
+  'iphone5' => 'iPhone Retina (4-inch)',
+  'iphone4' => 'iPhone Retina (3.5-inch)',
+  'ipad2' => 'iPad 2',
+  'ipad_air' => 'iPad Air',
+  'ipad_retina' => 'iPad Retina',
+  'ipad_resizable' => 'Resizable iPad'
+}
+
 class XCListen
 
   attr_reader :device
@@ -15,17 +26,6 @@ class XCListen
     @workspace = opts[:workspace] || workspace_path
     @device = IOS_DEVICES[opts[:device]] || IOS_DEVICES['iphone5s']
   end
-
-  IOS_DEVICES = {
-    # TODO Update iPhone names.
-    'iphone5s' => 'iPhone Retina (4-inch 64-bit)',
-    'iphone5' => 'iPhone Retina (4-inch)',
-    'iphone4' => 'iPhone Retina (3.5-inch)',
-    'ipad2' => 'iPad 2',
-    'ipad_air' => 'iPad Air',
-    'ipad_retina' => 'iPad Retina',
-    'ipad_resizable' => 'Resizable iPad'
-  }
 
   def workspace_path
     @workspace_path ||= Dir.glob("**/*.xcworkspace").sort_by(&:length).first

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -4,13 +4,13 @@ require 'listen'
 
 IOS_DEVICES = {
   # TODO Update iPhone names.
-  'iphone5s' => 'iPhone Retina (4-inch 64-bit)',
-  'iphone5' => 'iPhone Retina (4-inch)',
-  'iphone4' => 'iPhone Retina (3.5-inch)',
-  'ipad2' => 'iPad 2',
-  'ipad_air' => 'iPad Air',
-  'ipad_retina' => 'iPad Retina',
-  'ipad_resizable' => 'Resizable iPad'
+  "iphone5s" => "iPhone Retina (4-inch 64-bit)",
+  "iphone5" => "iPhone Retina (4-inch)",
+  "iphone4" => "iPhone Retina (3.5-inch)",
+  "ipad2" => "iPad 2",
+  "ipad_air" => "iPad Air",
+  "ipad_retina" => "iPad Retina",
+  "ipad_resizable" => "Resizable iPad"
 }
 
 class XCListen

--- a/lib/xclisten.rb
+++ b/lib/xclisten.rb
@@ -17,12 +17,14 @@ class XCListen
   end
 
   IOS_DEVICES = {
+    # TODO Update iPhone names.
     'iphone5s' => 'iPhone Retina (4-inch 64-bit)',
     'iphone5' => 'iPhone Retina (4-inch)',
     'iphone4' => 'iPhone Retina (3.5-inch)',
-    'ipad2' => 'iPad',
-    'ipad4' => 'iPad Retina',
-    'ipad_air' => 'iPad Retina (64-bit)'
+    'ipad2' => 'iPad 2',
+    'ipad_air' => 'iPad Air',
+    'ipad_retina' => 'iPad Retina',
+    'ipad_resizable' => 'Resizable iPad'
   }
 
   def workspace_path


### PR DESCRIPTION
I'm using Xcode 6 beta5. Names of the devices have changed around a bit. I think it's best to provide a universal default but the name should be completely overridable.
